### PR TITLE
BnB: Add ability to specify integers

### DIFF
--- a/gilp/tests/test_simplex.py
+++ b/gilp/tests/test_simplex.py
@@ -390,7 +390,8 @@ def test_get_vertices_equality_lp():
 def test_branch_and_bound_manual():
     lp = gilp.LP(np.array([[1,1],[5,9]]),
                  np.array([[6],[45]]),
-                 np.array([[5],[8]]))
+                 np.array([[5],[8]]),
+                 integrality=[1,1])
     with mock.patch('builtins.input', return_value="0"):
         with pytest.raises(ValueError,match='index can not be branched on.'):
             iteration = branch_and_bound_iteration(lp, None, None, True)
@@ -399,41 +400,50 @@ def test_branch_and_bound_manual():
         assert not iteration.fathomed
         assert iteration.incumbent is None
         assert iteration.best_bound is None
-        assert all(gilp.simplex(iteration.right_LP).x[:2]
+        assert all(gilp.simplex(iteration.right_LP.get_relaxation()).x[:2]
                    == np.array([[1.8],[4]]))
-        assert all(gilp.simplex(iteration.left_LP).x[:2]
+        assert all(gilp.simplex(iteration.left_LP.get_relaxation()).x[:2]
                    == np.array([[3],[3]]))
 
 
 @pytest.mark.parametrize("lp,x,val",[
     (gilp.LP(np.array([[-2,2],[2,2]]),
              np.array([[1],[7]]),
-             np.array([[1],[2]])),
+             np.array([[1],[2]]),
+             integrality=[1,1]),
      np.array([[2],[1]]),
      4.0),
     (gilp.LP(np.array([[1,1],[5,9]]),
              np.array([[6],[45]]),
-             np.array([[5],[8]])),
+             np.array([[5],[8]]),
+             integrality=[1,1]),
      np.array([[0],[5]]),
      40.0),
     (gilp.LP(np.array([[1,10],[1,0]]),
              np.array([[20],[2]]),
-             np.array([[0],[5]])),
+             np.array([[0],[5]]),
+             integrality=[1,1]),
      np.array([[0],[2]]),
      10.0),
     (gilp.LP(np.array([[-2,2,1,0],[2,2,0,1]]),
              np.array([[1],[7]]),
-             np.array([[1],[2],[0],[0]]),equality=True),
+             np.array([[1],[2],[0],[0]]),
+             equality=True,
+             integrality=[1,1,1,1]),
      np.array([[2],[1],[3],[1]]),
      4.0),
     (gilp.LP(np.array([[1,1,1,0],[5,9,0,1]]),
              np.array([[6],[45]]),
-             np.array([[5],[8],[0],[0]]),equality=True),
+             np.array([[5],[8],[0],[0]]),
+             equality=True,
+             integrality=[1,1,1,1]),
      np.array([[0],[5],[1],[0]]),
      40.0),
     (gilp.LP(np.array([[1,10,1,0],[1,0,0,1]]),
              np.array([[20],[2]]),
-             np.array([[0],[5],[0],[0]]),equality=True),
+             np.array([[0],[5],[0],[0]]),
+             equality=True,
+             integrality=[1,1,1,1]),
      np.array([[0],[2],[0],[2]]),
      10.0)])
 def test_branch_and_bound(lp,x,val):

--- a/gilp/visualize.py
+++ b/gilp/visualize.py
@@ -750,7 +750,7 @@ def bnb_visual(lp: LP,
     nodes_ct = 1
 
     # Get the axis limits to be used in all figures
-    limits = lp_visual(lp).get_axis_limits()
+    limits = lp_visual(lp.get_relaxation()).get_axis_limits()
 
     # Run the branch and bound algorithm
     while len(unexplored) > 0:
@@ -762,7 +762,7 @@ def bnb_visual(lp: LP,
 
         # Solve the LP relaxation
         try:
-            sol = simplex(lp=current)
+            sol = simplex(lp=current.get_relaxation())
             x = sol.x
             value = sol.obj_val
             x_str = ', '.join(map(str, [num_format(i) for i in x[:lp.n]]))
@@ -825,7 +825,7 @@ def bnb_visual(lp: LP,
         # Add path of simplex for the current node's LP
         try:
             simplex_path_slider(fig=fig,
-                                lp=current,
+                                lp=current.get_relaxation(),
                                 slider_pos='bottom',
                                 show_lp=False)
             for i in fig.get_indices('path', containing=True):
@@ -834,7 +834,7 @@ def bnb_visual(lp: LP,
             pass
 
         # Add objective slider
-        iso_slider = isoprofit_slider(fig, current)
+        iso_slider = isoprofit_slider(fig, current.get_relaxation())
         fig.update_layout(sliders=[iso_slider])
         fig.update_sliders()
 


### PR DESCRIPTION
@henryrobbins Thanks for your response in https://github.com/engri-1101/gilp/issues/16. Here is what had put together, though I don't have a quick example to test (beyond the included tests).

I'm still not sure about what is happening in `visualize.py`, but I may take a look at it later. Meanwhile, I'd appreciate your comments on this.

One question about the slack variables: In the original code is it correct to do `if np.sum(frac_comp) > 0:` once slack variables are added? Could this not lead to a case where you are branching on a slack variable, which is not necessarily correct?

Todo:
- [x] Adjust `LP` to support specifying `integrality`
- [x] Change `simplex` and `branch_and_bound` to support `integrality`
- [x] Fix tests broken by the above
- [ ] Refactor `bnb_visual`
- [ ] Add more tests for MILPs